### PR TITLE
feat: bump compose files to reflect version changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dbfree
 node_modules
+database/apex

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This directory contains all the code used in my JavaScript blog posts at <https:
 
 | Project | Contents | Link to post |
 | -- | -- | -- |
-| database | {Podman,Docker} compose files to create a new Oracle Database Free 23ai instance | |
+| [database](database/README.md) | {Podman,Docker} compose files to create a new Oracle Database Free 23ai instance as well as an ORDS and/or APEX environment | |
 | [express-mle-javascript](./express-mle-javascript/readme.md) | Short example showing how to combine node-express and MLE/JavaScript | [Blog Post](https://martincarstenbach.com/2025/01/17/node-express-mle-javascript-example/) |
 | [graphql-simplified](./graphql-simplified/README.md) | Simplified version of the original GraphQL Example | [Blog Post](https://martincarstenbach.com/2024/06/06/creating-a-graphql-endpoint-within-the-database-redux/) |
 | [mle-typescript](./mle-typescript/README.md) | Example for migrating from plain JavaScript to TypeScript to make use of type-checking and linting | [Readme](./mle-typescript/README.md) |

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,36 @@
+# Compose files for Oracle Database 23ai
+
+This directory contains compose files for `docker-compose` and `podman-compose` respectively. Tested using Oracle Linux 9.6 on Linux x86-64 using
+
+- podman 5.4.0
+- podman-compose 1.4.0
+
+Oracle Linux 9.6 ships with too old a podman-compose release (1.0.6), make sure to install the current one into a venv, like so:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install podman-compose
+podman-compose --version
+```
+
+Podman-compose must report at least version 1.4.0.
+
+## If "just a database" is all you need
+
+Use either the following files to create an [Oracle Database 23ai Free](https://www.oracle.com/database/free/) instance:
+
+- compose-docker-db.yml
+- compose-podman-db.yml
+
+The latter requires you to create a [Podman secret](https://martincarstenbach.com/2022/12/19/podman-secrets-a-better-way-to-pass-environment-variables-to-containers/), **oracle-passwd**, to set the initial SYS and SYSTEM passwords. Docker doesn't support secrets in the same way, in that case make sure to change the passwords after the initial setup if that's important to you.
+
+Both compose files mount the initialisation directory into the database container, creating a demo account (demouser) for you to play with. This account is also referenced extensively on the blog.
+
+## Oracle REST Data Services and/or APEX
+
+If you want to [REST-enable](https://www.oracle.com/ords) your database or create an [APEX](https://apex.oracle.com) development instance, you can use `compose-apex.yml` for a hands-free setup experience.
+
+ORDS will always be installed. If you want to additionally install APEX, make sure to [download APEX](https://www.oracle.com/tools/downloads/apex-downloads/) from Oracle's website, unzip it in `database/apex` and uncomment line 30 in the compose file to mount the installation directory into the ORDS container.
+
+Note that there is no support for Podman secrets in this compose file, if I can find a way to make them work I'll provide an update.

--- a/database/compose-docker-db.yml
+++ b/database/compose-docker-db.yml
@@ -1,20 +1,20 @@
 # THIS IS NOT A PRODUCTION SETUP - LAB USE ONLY!
 services:
   oracle:
-    image: docker.io/gvenzl/oracle-free:23.7
+    image: container-registry.oracle.com/database/free:23.8.0.0
     ports:
       - 1521:1521
     environment:
       - ORACLE_PASSWORD=changeOnInstall
-      - APP_USER=demouser
-      - APP_USER_PASSWORD_FILE=demouser
+      - ORACLE_PDB=freepdb1
+      - DBHOST=db
     volumes:
       - oradata-vol:/opt/oracle/oradata
-      - ./initialisation:/container-entrypoint-initdb.d
+      - ./initialisation:/opt/oracle/scripts/startup
     networks:
       - backend
     healthcheck:
-      test: ["CMD", "healthcheck.sh"]
+      test: [ "CMD", "/opt/oracle/checkDBStatus.sh" ]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/database/compose-podman-apex.yml
+++ b/database/compose-podman-apex.yml
@@ -1,0 +1,41 @@
+# THIS IS NOT A PRODUCTION SETUP - LAB USE ONLY!
+services:
+    oracle:
+        image: container-registry.oracle.com/database/free:23.8.0.0
+        ports:
+            - 1521:1521
+        environment:
+            - ORACLE_PWD=changeOnInstall
+        volumes:
+            - oradata-vol:/opt/oracle/oradata
+            - ./initialisation:/opt/oracle/scripts/startup:Z
+        networks:
+            - backend
+        healthcheck:
+            test: [ "CMD", "/opt/oracle/checkDBStatus.sh" ]
+            interval: 10s
+            timeout: 5s
+            retries: 10
+
+    ords:
+        depends_on:
+            oracle:
+                condition: service_healthy
+        image: container-registry.oracle.com/database/ords:25.1.1
+        environment:
+          - CONN_STRING=database_oracle_1/freepdb1
+          - ORACLE_PWD=changeOnInstall
+        ports:
+          - 8080:8080
+          - 8443:8443
+          - 27017:27017
+        volumes:
+            - ords-config-vol:/etc/ords/config
+            # - ./apex:/opt/oracle/apex:Z
+
+volumes:
+    oradata-vol:
+    ords-config-vol:
+
+networks:
+    backend:

--- a/database/compose-podman-db.yml
+++ b/database/compose-podman-db.yml
@@ -1,20 +1,18 @@
 # THIS IS NOT A PRODUCTION SETUP - LAB USE ONLY!
 services:
     oracle:
-        image: docker.io/gvenzl/oracle-free:23.7
+        image: container-registry.oracle.com/database/free:23.8.0.0
         ports:
             - 1521:1521
         environment:
             - ORACLE_PASSWORD_FILE=/run/secrets/oracle-passwd
-            - APP_USER=demouser
-            - APP_USER_PASSWORD_FILE=/run/secrets/app-passwd
         volumes:
             - oradata-vol:/opt/oracle/oradata
-            - ./initialisation:/container-entrypoint-initdb.d:Z
+            - ./initialisation:/opt/oracle/scripts/startup:Z
         networks:
             - backend
         healthcheck:
-            test: ["CMD", "healthcheck.sh"]
+            test: [ "CMD", "/opt/oracle/checkDBStatus.sh" ]
             interval: 10s
             timeout: 5s
             retries: 10
@@ -31,6 +29,4 @@ networks:
 
 secrets:
     oracle-passwd:
-        external: true
-    app-passwd:
         external: true

--- a/database/initialisation/01_grants_demouser.sql
+++ b/database/initialisation/01_grants_demouser.sql
@@ -1,5 +1,10 @@
 alter session set container = freepdb1;
 
+create user if not exists demouser identified by demouser
+quota 1g on users;
+
+grant db_developer_role to demouser;
+
 prompt JavaScript grants...
 grant execute on javascript to demouser;
 grant execute dynamic mle to demouser;


### PR DESCRIPTION
This Pull Requests:

- bumps the Oracle Database Free container image from 23.7 to 23.8
- uses the official images from https://container-registry.oracle.com
- amends the initialisation scripts
- adds an additional compose file to [REST-enable](https://www.oracle.com/ords) the database and/or create an [APEX](https://apex.oracle.com) development environment
- updates the corresponding readme files