### PR TITLE
doc: hotfix to add missing closing bracket in link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This directory contains all the code used in my JavaScript blog posts at <https:
 | [mle-typescript](./mle-typescript/README.md) | Example for migrating from plain JavaScript to TypeScript to make use of type-checking and linting | [Readme](./mle-typescript/README.md) |
 | [mle-sqlcl-liquibase](./mle-sqlcl-liquibase/readme.md) | DEPRECATED Example how to use `runOraclescript` to create MLE/JavaScript modules. SQLcl now supports MLE modules natively | [Blog Post](https://martincarstenbach.com/2024/08/15/create-mle-javascript-modules-using-liquibase/) |
 | [timeout-polyfill](./timeout-polyfill/readme.md) | An example how to provide a polyfill for `setTimeout()` in MLE 23.8 | [Blog Post](https://martincarstenbach.com/2025/05/22/multilingual-engine-polyfill-timeouts-and-intervals/) |
-| [post-execution-debugging](post-execution-debugging/README.md) | An example how to use the new post-execution-debugging feature introduced in SQLDeveloper Extension for VSCode 25.3.0 | [blog post(https://martincarstenbach.com/2025/10/07/intro-to-post-execution-debugging-in-sql-developer-for-vscode/) |
+| [post-execution-debugging](post-execution-debugging/README.md) | An example how to use the new post-execution-debugging feature introduced in SQLDeveloper Extension for VSCode 25.3.0 | [blog post](https://martincarstenbach.com/2025/10/07/intro-to-post-execution-debugging-in-sql-developer-for-vscode/) |
 
 ## Disclaimer
 


### PR DESCRIPTION
the link in the table was broken